### PR TITLE
[Davranbek Jenisbaev]: Implement RBAC

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import { notFoundMiddleware } from "#/shared/middlewares/not-found.middleware";
 import { errorMiddleware } from "#/shared/middlewares/error.middleware";
 import { auth } from "./shared/middlewares/auth.middleware";
 import { CommentsController } from "./modules/comments/comments.controller";
+import { UsersController } from "./modules/users/users.controller";
 
 export const app = express();
 
@@ -29,6 +30,7 @@ app.get("/health", async (_req: Request, res: Response) => {
 app.use("/auth", AuthController);
 app.use("/blogs", BlogsController);
 app.use("/", CommentsController);
+app.use("/users", UsersController);
 
 app.use(notFoundMiddleware);
 app.use(errorMiddleware);

--- a/src/modules/auth/tests/auth.controller.spec.ts
+++ b/src/modules/auth/tests/auth.controller.spec.ts
@@ -2,7 +2,8 @@ import request from "supertest";
 import { AuthController } from "../auth.controller";
 import { AuthService } from "../auth.service";
 import express from "express";
-import { Role, User } from "#/modules/users/entities/user.entity";
+import { User } from "#/modules/users/entities/user.entity";
+import { UserRole } from "#/shared/constants/user-role.constant";
 
 const app = express();
 app.use(express.json());
@@ -13,7 +14,7 @@ const mockUser: User = {
 	email: "davranbek@example.com",
 	username: "davranbek",
 	password: "123123123",
-	role: Role.USER,
+	role: UserRole.USER,
 	createdAt: new Date(),
 };
 

--- a/src/modules/auth/tests/auth.service.spec.ts
+++ b/src/modules/auth/tests/auth.service.spec.ts
@@ -4,7 +4,8 @@ import { UnauthorizedError } from "#/shared/errors/unauthorized.error";
 import bcrypt from "bcrypt";
 import { generateJwtToken } from "#/shared/utils/generateToken";
 import { BadRequestError } from "#/shared/errors/bad-request.error";
-import { Role, User } from "#/modules/users/entities/user.entity";
+import { User } from "#/modules/users/entities/user.entity";
+import { UserRole } from "#/shared/constants/user-role.constant";
 import { envConfig } from "#/config/env.config";
 
 jest.mock("#/shared/utils/generateToken");
@@ -15,7 +16,7 @@ const mockUser: User | null = {
 	email: "davranbek@example.com",
 	username: "davranbek",
 	password: "123123123",
-	role: Role.USER,
+	role: UserRole.USER,
 	createdAt: new Date(),
 };
 

--- a/src/modules/comments/tests/comments.controller.spec.ts
+++ b/src/modules/comments/tests/comments.controller.spec.ts
@@ -12,10 +12,10 @@ app.use("/", CommentsController);
 jest.mock("../comments.service");
 
 jest.mock("#/shared/middlewares/auth.middleware", () => ({
-	auth: jest.fn((req: Request, _res: Response, next: NextFunction) => {
+	auth: (req: Request, _res: Response, next: NextFunction) => {
 		req.user = { id: "1", role: "user" };
 		next();
-	}),
+	},
 }));
 
 jest.mock("#/shared/validators/path-parameter.validator", () => ({

--- a/src/modules/users/dto/request/update-user-role-request-body.dto.ts
+++ b/src/modules/users/dto/request/update-user-role-request-body.dto.ts
@@ -1,0 +1,12 @@
+import { UserRole } from "#/shared/constants/user-role.constant";
+import { z } from "zod";
+
+export const updateUserRoleRequestBodyDtoSchema = z.object({
+	role: z.enum([UserRole.USER, UserRole.ADMIN], {
+		message: `Role must be one of the following: ${Object.values(UserRole).join(", ")}`,
+	}),
+});
+
+export type UpdateUserRoleRequestBodyDto = z.infer<
+	typeof updateUserRoleRequestBodyDtoSchema
+>;

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -1,9 +1,5 @@
+import { UserRole } from "#/shared/constants/user-role.constant";
 import { Entity, Column, CreateDateColumn, PrimaryGeneratedColumn } from "typeorm";
-
-export enum Role {
-	ADMIN = "admin",
-	USER = "user",
-}
 
 @Entity({ name: "user" })
 export class User {
@@ -19,8 +15,8 @@ export class User {
 	@Column({ type: "char", length: 60 })
 	password!: string;
 
-	@Column({ type: "enum", enum: Role, default: Role.USER })
-	role!: Role;
+	@Column({ type: "enum", enum: UserRole, default: UserRole.USER })
+	role!: UserRole;
 
 	@CreateDateColumn({
 		type: "timestamptz",

--- a/src/modules/users/tests/users.controller.spec.ts
+++ b/src/modules/users/tests/users.controller.spec.ts
@@ -1,0 +1,72 @@
+import express, { Request, Response, NextFunction } from "express";
+import request from "supertest";
+import { UsersController } from "../users.controller";
+import { UsersService } from "../users.service";
+import { UserRole } from "#/shared/constants/user-role.constant";
+import { User } from "../entities/user.entity";
+
+const app = express();
+
+app.use(express.json());
+
+app.use("/users", UsersController);
+
+jest.mock("../users.service");
+
+jest.mock("#/shared/middlewares/auth.middleware", () => ({
+	auth: (req: Request, _res: Response, next: NextFunction) => {
+		req.user = { id: "1", role: "user" };
+		next();
+	},
+}));
+
+jest.mock("#/shared/middlewares/require-role.middleware", () => ({
+	requireRole: () => (req: Request, _res: Response, next: NextFunction) => {
+		next();
+	},
+}));
+
+jest.mock("#/shared/validators/path-parameter.validator", () => ({
+	validatePathParameter: () => (_req: Request, _res: Response, next: NextFunction) =>
+		next(),
+}));
+
+jest.mock("#/shared/validators/request-body.validator", () => ({
+	validateRequestBody: () => (_req: Request, _res: Response, next: NextFunction) => {
+		next();
+	},
+}));
+
+const mockUser: User = {
+	id: "1",
+	email: "davranbek@example.com",
+	username: "davranbek",
+	password: "123123123",
+	role: UserRole.USER,
+	createdAt: new Date(),
+};
+
+describe("UsersController", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe("PUT /users/:id/role", () => {
+		it("should update user role", async () => {
+			(UsersService.updateUserRole as jest.Mock).mockResolvedValueOnce(mockUser);
+
+			const response = await request(app)
+				.put("/users/" + 1 + "/role")
+				.send({
+					role: "admin",
+				});
+
+			expect(response.status).toBe(200);
+			expect(response.body.data).toEqual({
+				...mockUser,
+				createdAt: mockUser.createdAt.toISOString(),
+			});
+			expect(response.body.message).toBe("User role updated successfully");
+		});
+	});
+});

--- a/src/modules/users/tests/users.service.spec.ts
+++ b/src/modules/users/tests/users.service.spec.ts
@@ -1,0 +1,50 @@
+import { UserRole } from "#/shared/constants/user-role.constant";
+import { NotFoundError } from "#/shared/errors/not-found.error";
+import { User } from "../entities/user.entity";
+import { UsersRepository } from "../users.repository";
+import { UsersService } from "../users.service";
+
+const mockUser: User = {
+	id: "1",
+	email: "davranbek@example.com",
+	username: "davranbek",
+	password: "123123123",
+	role: UserRole.USER,
+	createdAt: new Date(),
+};
+
+describe("UsersService", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe("updateUserRole", () => {
+		const updateUserRoleData = {
+			role: UserRole.ADMIN,
+		};
+
+		it("should return updated user with updated role", async () => {
+			const repositorySpy = jest
+				.spyOn(UsersRepository, "updateOne")
+				.mockResolvedValue(mockUser);
+
+			const result = await UsersService.updateUserRole(updateUserRoleData, mockUser.id);
+
+			expect(result).toEqual(mockUser);
+			expect(repositorySpy).toHaveBeenCalledTimes(1);
+			expect(repositorySpy).toHaveBeenLastCalledWith(updateUserRoleData, mockUser.id);
+		});
+
+		it("should throw NotFoundError if user is not found", async () => {
+			const repositorySpy = jest
+				.spyOn(UsersRepository, "updateOne")
+				.mockResolvedValue(null);
+
+			expect(
+				UsersService.updateUserRole(updateUserRoleData, mockUser.id)
+			).rejects.toThrow(NotFoundError);
+			expect(repositorySpy).toHaveBeenCalledTimes(1);
+			expect(repositorySpy).toHaveBeenLastCalledWith(updateUserRoleData, mockUser.id);
+		});
+	});
+});

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,0 +1,33 @@
+import "express-async-errors";
+import { Request, Response } from "express";
+import { Router } from "express";
+import { UsersService } from "./users.service";
+import { validateRequestBody } from "#/shared/validators/request-body.validator";
+import { updateUserRoleRequestBodyDtoSchema } from "./dto/request/update-user-role-request-body.dto";
+import { validatePathParameter } from "#/shared/validators/path-parameter.validator";
+import { uuidSchema } from "#/shared/schemas/uuid.schema";
+import { auth } from "#/shared/middlewares/auth.middleware";
+import { requireRole } from "#/shared/middlewares/require-role.middleware";
+import { UserRole } from "#/shared/constants/user-role.constant";
+
+export const UsersController = Router();
+
+UsersController.put(
+	"/:userId/role",
+	auth,
+	requireRole(UserRole.ADMIN),
+	validatePathParameter("userId", uuidSchema),
+	validateRequestBody(updateUserRoleRequestBodyDtoSchema),
+
+	async (req: Request, res: Response) => {
+		const updatedUser = await UsersService.updateUserRole(
+			req.body,
+			req.params["userId"] || ""
+		);
+
+		return res.status(200).json({
+			data: updatedUser,
+			message: "User role updated successfully",
+		});
+	}
+);

--- a/src/modules/users/users.repository.ts
+++ b/src/modules/users/users.repository.ts
@@ -19,4 +19,16 @@ export class UsersRepository {
 
 		return await this.repository.save(newUser);
 	}
+
+	static async updateOne(data: Partial<User>, userId: string): Promise<User | null> {
+		const user = await this.repository.findOne({ where: { id: userId } });
+
+		if (!user) {
+			return null;
+		}
+
+		const updatedUser = await this.repository.save({ ...user, ...data });
+
+		return updatedUser;
+	}
 }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,0 +1,19 @@
+import { User } from "./entities/user.entity";
+import { UpdateUserRoleRequestBodyDto } from "./dto/request/update-user-role-request-body.dto";
+import { UsersRepository } from "./users.repository";
+import { NotFoundError } from "#/shared/errors/not-found.error";
+
+export class UsersService {
+	static async updateUserRole(
+		dto: UpdateUserRoleRequestBodyDto,
+		userId: string
+	): Promise<User> {
+		const updatedUser = await UsersRepository.updateOne(dto, userId);
+
+		if (!updatedUser) {
+			throw new NotFoundError("User not found");
+		}
+
+		return updatedUser;
+	}
+}

--- a/src/shared/constants/user-role.constant.ts
+++ b/src/shared/constants/user-role.constant.ts
@@ -1,0 +1,4 @@
+export enum UserRole {
+	ADMIN = "admin",
+	USER = "user",
+}

--- a/src/shared/middlewares/require-role.middleware.ts
+++ b/src/shared/middlewares/require-role.middleware.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from "express";
+import { UnauthorizedError } from "../errors/unauthorized.error";
+import { UserRole } from "../constants/user-role.constant";
+
+export function requireRole(requiredRole: UserRole) {
+	return (req: Request, _res: Response, next: NextFunction) => {
+		const currentRole = req?.user.role;
+
+		if (!currentRole) {
+			throw new UnauthorizedError("Unauthorized");
+		}
+
+		if (currentRole !== requiredRole) {
+			throw new UnauthorizedError(
+				"You do not have the required role to access this resource"
+			);
+		}
+
+		next();
+	};
+}


### PR DESCRIPTION
# Summary

 - [x] Added "Require Role" middleware for role-based access control 
 - [x] Added endpoint to update user role (to demote or promote users)
 - [x] Added unit tests for user role promotion and demotion in user controller and service

# Details

I have already implemented role-based restrictions for blog and comment management routes in my previous Pull Requests.

I also already have a middleware for verifying jwt tokens and doing authentication. That is why this new "requireRole" middleware only verifies user roles and does only authorization.

So my authentication and authorization functionality are in separate middleware and decoupled.